### PR TITLE
Add 30 day log retention to RunPageSpeed Lambda

### DIFF
--- a/infrastructure/main.yml
+++ b/infrastructure/main.yml
@@ -299,6 +299,12 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/${LambdaAPIAuditsShow}"
       RetentionInDays: 30
 
+  LogGroupLambdaAPIRunPageSpeed:
+    Type: "AWS::Logs::LogGroup"
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${LambdaAPIRunPageSpeed}"
+      RetentionInDays: 30
+
   LogGroupLambdaStreamAuditsDelete:
     Type: "AWS::Logs::LogGroup"
     Properties:


### PR DESCRIPTION
The `LambdaAPIRunPageSpeed` lambda was missing a Log Group definition