### PR TITLE
Pass ENV to CloudFormation for tags & s3 bucket name

### DIFF
--- a/infrastructure/main.yml
+++ b/infrastructure/main.yml
@@ -13,6 +13,9 @@ Parameters:
     Type: String
     NoEcho: true
     Description: Enter your PageSpeed Insights API key (optional)
+  Env:
+    Type: String
+    Description: The environment name (eg, staging)
 
 Resources:
   # Roles & Permissions
@@ -89,6 +92,7 @@ Resources:
   BucketAudits:
     Type: "AWS::S3::Bucket"
     Properties:
+      BucketName: !Sub "pickle-audits-${Env}"
       PublicAccessBlockConfiguration:
         BlockPublicAcls: false
         BlockPublicPolicy: false

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -26,4 +26,4 @@ aws cloudformation deploy \
     --template-file dist/template.${STACK_ENV}.yml \
     --stack-name ${STACK_NAME} \
     --capabilities CAPABILITY_IAM \
-    --parameter-overrides PageSpeedInsightsKeys="${PAGESPEED_INSIGHTS_API}"
+    --parameter-overrides PageSpeedInsightsKeys="${PAGESPEED_INSIGHTS_API}" Env="${STACK_ENV}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -26,4 +26,5 @@ aws cloudformation deploy \
     --template-file dist/template.${STACK_ENV}.yml \
     --stack-name ${STACK_NAME} \
     --capabilities CAPABILITY_IAM \
-    --parameter-overrides PageSpeedInsightsKeys="${PAGESPEED_INSIGHTS_API}" Env="${STACK_ENV}"
+    --parameter-overrides PageSpeedInsightsKeys="${PAGESPEED_INSIGHTS_API}" Env="${STACK_ENV}" \
+    --tags Env="${STACK_ENV}"


### PR DESCRIPTION
Passed in the `STACK_ENV` variable as a new Parameter `Env` which allows for better naming of the S3 bucket... Also added the `Env` tag to resources in the stack.